### PR TITLE
fix missing libgralloc_drm

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -6,9 +6,13 @@
   <remote name="android_default" fetch="https://android.googlesource.com/"/>
   <remote name="mesa" fetch="https://gitlab.freedesktop.org/mesa/"/>
  
-  <project path="external/drm_gralloc" name="platform/external/drm_gralloc" revision="master" remote="android_default"/>
+    <!--<project path="external/drm_gralloc" name="platform/external/drm_gralloc" revision="master" remote="android_default"/>-->
+  <project path="external/drm_gralloc" name="external_drm_gralloc" revision="rpi3-19.1" remote="arpi"/>
+
   <remove-project name="platform/external/mesa3d"/>
-  <project path="external/mesa3d" name="mesa" revision="master" remote="mesa"/>
+    <!--<project path="external/mesa3d" name="mesa" revision="master" remote="mesa"/>-->
+  <project path="external/mesa3d" name="external_mesa3d" revision="rpi3-19.1" remote="arpi"/>
+
   <project path="kernel/rpi" name="linux" revision="rpi-4.19.y" remote="RaspberryPiFan"/>
   <project path="hardware/rpi" name="hardware_rpi" revision="android10" remote="RaspberryPiFan"/>
   <project path="device/brcm/rpi3" name="device_brcm_rpi4" revision="android-10" remote="RaspberryPiFan"/>

--- a/default.xml
+++ b/default.xml
@@ -7,7 +7,7 @@
   <remote name="mesa" fetch="https://gitlab.freedesktop.org/mesa/"/>
  
     <!--<project path="external/drm_gralloc" name="platform/external/drm_gralloc" revision="master" remote="android_default"/>-->
-  <project path="external/drm_gralloc" name="external_drm_gralloc" revision="rpi3-19.1" remote="arpi"/>
+  <project path="external/drm_gralloc" name="external_drm_gralloc" revision="v3d" remote="RaspberryPiFan"/>
 
   <remove-project name="platform/external/mesa3d"/>
     <!--<project path="external/mesa3d" name="mesa" revision="master" remote="mesa"/>-->


### PR DESCRIPTION
These two repos fix the libgralloc_drm, haven't got the time to compare yet see what's missing in currect repo of default.xml.